### PR TITLE
Fix #123: Fix schema issues in report_customsql_categories

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -269,5 +269,21 @@ function xmldb_report_customsql_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2021111600, 'report', 'customsql');
     }
 
+    if ($oldversion < 2022031801) {
+
+        // Changing nullability of field name on table report_customsql_categories to not null.
+        // Changing the default of field name on table report_customsql_categories to drop it.
+        $table = new xmldb_table('report_customsql_categories');
+        $field = new xmldb_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, 'id');
+
+        // Launch change of nullability for field name.
+        $dbman->change_field_notnull($table, $field);
+        // Launch change of default for field name.
+        $dbman->change_field_default($table, $field);
+
+        // Report savepoint reached.
+        upgrade_plugin_savepoint(true, 2022031801, 'report', 'customsql');
+    }
+
     return true;
 }

--- a/tests/local/category_test.php
+++ b/tests/local/category_test.php
@@ -28,7 +28,7 @@ require_once($CFG->dirroot . '/report/customsql/locallib.php');
  * @copyright 2021 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class _category_test extends \advanced_testcase {
+class category_test extends \advanced_testcase {
     /**
      * Test create category.
      */

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022031800;
+$plugin->version   = 2022031801;
 $plugin->requires  = 2020061500;
 $plugin->component = 'report_customsql';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Fixes issue https://github.com/moodleou/moodle-report_customsql/issues/123

```
-------------------------------------------------------------------------------
report_customsql_categories
 * column 'name' should be NOT NULL (C)
 * column 'name' has default 'Miscellaneous', expected 'NULL' (C)
-------------------------------------------------------------------------------
```

At some point the name columns constraint has been changed to NULL leading to this error.